### PR TITLE
feat: migrate save_static_file to ProjectFileDestination

### DIFF
--- a/topazlabs/base_topaz_node.py
+++ b/topazlabs/base_topaz_node.py
@@ -7,7 +7,7 @@ from constants import API_KEY_ENV_VAR, OUTPUT_FORMATS
 from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from topaz_client import TopazClient
@@ -59,6 +59,14 @@ class BaseTopazNode(ControlNode):
         3. Output parameters
         4. Status parameter
         """
+        # File destination parameter for configuring where output is saved
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="processed_image.jpeg",
+        )
+        self._output_file.add_parameter()
+
         # Common output parameter for processed image
         self.add_parameter(
             Parameter(
@@ -177,27 +185,9 @@ class BaseTopazNode(ControlNode):
             Exception: If saving fails
         """
         try:
-            # Import inside method to avoid caching issues
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            # Get output format
-            output_format = self.get_parameter_value("output_format") or "jpeg"
-
-            # Generate unique filename with timestamp and hash (following kontext pattern)
-            import hashlib
-            import time
-
-            timestamp = int(time.time() * 1000)  # milliseconds for uniqueness
-            content_hash = hashlib.md5(image_data).hexdigest()[:8]  # Short hash of content
-            filename = f"{filename_hint}_{timestamp}_{content_hash}.{output_format.lower()}"
-
-            # Save to managed file location and get URL
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                image_data, filename, ExistingFilePolicy.CREATE_NEW
-            )
-
-            return ImageUrlArtifact(value=static_url, name=f"{filename_hint}_{timestamp}")
-
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(image_data)
+            return ImageUrlArtifact(value=saved.location, name=filename_hint)
         except Exception as e:
             raise Exception(f"Failed to save output image: {str(e)}")
 

--- a/topazlabs/base_topaz_node.py
+++ b/topazlabs/base_topaz_node.py
@@ -8,6 +8,7 @@ from griptape.artifacts import ImageArtifact, ImageUrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from topaz_client import TopazClient
@@ -140,7 +141,10 @@ class BaseTopazNode(ControlNode):
             # Debug info to track image changes - create a hash to detect changes
             import hashlib
 
-            if isinstance(image_artifact, (ImageArtifact, ImageUrlArtifact)):
+            if isinstance(image_artifact, ImageUrlArtifact):
+                # Use File to resolve template paths like {outputs}/... to real file paths
+                image_bytes = File(image_artifact.value).read_bytes()
+            elif isinstance(image_artifact, ImageArtifact):
                 image_bytes = image_artifact.to_bytes()
             else:
                 # Try to convert to bytes if it's a different artifact type

--- a/topazlabs/base_topaz_video_node.py
+++ b/topazlabs/base_topaz_video_node.py
@@ -18,7 +18,7 @@ from constants import (
 from griptape.artifacts import BlobArtifact, UrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
-from griptape_nodes.retained_mode.events.os_events import ExistingFilePolicy
+from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
@@ -184,6 +184,14 @@ class BaseTopazVideoNode(ControlNode):
         3. Output parameters
         4. Status parameter (always last)
         """
+        # File destination parameter for configuring where output is saved
+        self._output_file = ProjectFileParameter(
+            node=self,
+            name="output_file",
+            default_filename="processed_video.mp4",
+        )
+        self._output_file.add_parameter()
+
         # Video output parameter
         self.add_parameter(
             Parameter(
@@ -315,24 +323,9 @@ class BaseTopazVideoNode(ControlNode):
             Exception: If saving fails
         """
         try:
-            # Import inside method to avoid caching issues
-            from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
-
-            # Get output format
-            output_container = self.get_parameter_value("output_container") or "mp4"
-
-            # Generate unique filename with timestamp and hash
-            timestamp = int(time.time() * 1000)  # milliseconds for uniqueness
-            content_hash = hashlib.md5(video_data).hexdigest()[:8]  # Short hash of content
-            filename = f"{filename_hint}_{timestamp}_{content_hash}.{output_container.lower()}"
-
-            # Save to managed file location and get URL
-            static_url = GriptapeNodes.StaticFilesManager().save_static_file(
-                video_data, filename, ExistingFilePolicy.CREATE_NEW
-            )
-
-            return VideoUrlArtifact(url=static_url, name=f"{filename_hint}_{timestamp}")
-
+            dest = self._output_file.build_file()
+            saved = dest.write_bytes(video_data)
+            return VideoUrlArtifact(url=saved.location, name=filename_hint)
         except Exception as e:
             raise Exception(f"Failed to save output video: {str(e)}")
 

--- a/topazlabs/base_topaz_video_node.py
+++ b/topazlabs/base_topaz_video_node.py
@@ -19,6 +19,7 @@ from griptape.artifacts import BlobArtifact, UrlArtifact
 from griptape_nodes.exe_types.core_types import Parameter, ParameterMode, ParameterTypeBuiltin
 from griptape_nodes.exe_types.node_types import AsyncResult, ControlNode
 from griptape_nodes.exe_types.param_components.project_file_parameter import ProjectFileParameter
+from griptape_nodes.files.file import File
 from griptape_nodes.retained_mode.griptape_nodes import GriptapeNodes
 from griptape_nodes.traits.options import Options
 from griptape_nodes.traits.slider import Slider
@@ -275,13 +276,14 @@ class BaseTopazVideoNode(ControlNode):
 
         try:
             # Extract video bytes
-            if isinstance(video_artifact, (VideoUrlArtifact, BlobArtifact)):
+            if isinstance(video_artifact, VideoUrlArtifact):
+                # Use File to resolve template paths like {outputs}/... to real file paths
+                video_bytes = File(video_artifact.value).read_bytes()
+            elif isinstance(video_artifact, BlobArtifact):
                 video_bytes = video_artifact.to_bytes()
-            elif hasattr(video_artifact, "to_bytes"):
-                # Handle VideoArtifact or other artifact types with to_bytes method
-                video_bytes = video_artifact.to_bytes()
+            elif hasattr(video_artifact, "value"):
+                video_bytes = File(video_artifact.value).read_bytes()
             else:
-                # Try to convert to bytes if it's a different artifact type
                 video_bytes = video_artifact.to_bytes()
 
             # Verify we have video data


### PR DESCRIPTION
Closes #6

Replace `StaticFilesManager.save_static_file()` with `ProjectFileDestination` in base class helper methods for project-aware file saving.